### PR TITLE
enable building with CMake 4.0

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
-    let mut install_dir = cmake::build("lzo");
+    let mut install_dir = cmake::Config::new("lzo")
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+        .build();
+
     install_dir.push("lib");
 
     println!("cargo:rustc-link-search=native={}", install_dir.display());


### PR DESCRIPTION
This update allows to build the crate with CMake 4.0, while keeping the LZO submodule unchanged.